### PR TITLE
Add na.rm option to build_dict to print range of non-NA values

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,4 +15,4 @@ LazyData: true
 Imports: dplyr
 Suggests: knitr, rmarkdown
 VignetteBuilder: knitr
-RoxygenNote: 6.0.1
+RoxygenNote: 6.1.1

--- a/R/build_dict.R
+++ b/R/build_dict.R
@@ -16,6 +16,8 @@
 #' @param prompt_varopts Logical. Whether to add the option_description manually 
 #' as prompted by R. Default is set to TRUE. If FALSE, an option_description vector 
 #' must be provided.
+#' @param na.rm Logical. Whether to remove \code{NA} when determining the range 
+#' for variables with \code{variable_type == 0} in \code{linker}
 #' @return A data frame that will serve as a data dictionary for an original dataset. 
 #' The user will have the option to add this dictionary as an attribute to the original 
 #' dataset with the other package functions.
@@ -42,7 +44,8 @@
 #' 
 #' @export
 
-build_dict <- function(my.data, linker, option_description = NULL, prompt_varopts = TRUE) {
+build_dict <- function(my.data, linker, option_description = NULL, prompt_varopts = TRUE,
+                       na.rm = FALSE) {
   
   error1 <- FALSE
   error2 <- FALSE
@@ -57,7 +60,7 @@ build_dict <- function(my.data, linker, option_description = NULL, prompt_varopt
     
     var.options = 
       ifelse(linker$var_type[i] == 1 & linker$var_name[i] == names(my.data[i]), 
-             unique(my.data[i]), paste(range(my.data[, i], na.rm = FALSE), 
+             unique(my.data[i]), paste(range(my.data[, i], na.rm = na.rm), 
                                        sep = "", collapse = " to "))
     
     d <- data.frame(

--- a/man/build_dict.Rd
+++ b/man/build_dict.Rd
@@ -5,7 +5,7 @@
 \title{Build a data dictionary for a dataset.}
 \usage{
 build_dict(my.data, linker, option_description = NULL,
-  prompt_varopts = TRUE)
+  prompt_varopts = TRUE, na.rm = FALSE)
 }
 \arguments{
 \item{my.data}{Data.frame. The data set for which the user is creating the 
@@ -23,6 +23,9 @@ this value must be NULL.}
 \item{prompt_varopts}{Logical. Whether to add the option_description manually 
 as prompted by R. Default is set to TRUE. If FALSE, an option_description vector 
 must be provided.}
+
+\item{na.rm}{Logical. Whether to remove \code{NA} when determining the range 
+for variables with \code{variable_type == 0} in \code{linker}}
 }
 \value{
 A data frame that will serve as a data dictionary for an original dataset. 


### PR DESCRIPTION
Thanks for this great package! I added a small tweak to allow a user to get variables that have a range printed to display the min/max values not counting NA values. I believe this shouldn't affect any existing code as I set the default value to `FALSE`, which matches what the code was earlier. Happy to discuss further if you'd like and thanks again!